### PR TITLE
Enable travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+  - "3.6.1"
+script:
+  - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ python:
   - "3.5"
   - "3.6.1"
 script:
-  - pytest tests --conf-key={KEY}
+  - pytest tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ python:
   - "3.5"
   - "3.6.1"
 script:
-  - pytest
+  - pytest tests --conf-key={KEY}

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ python:
   - "3.6.1"
 install:
   - pip install kount_ris_sdk
+  - pip install .[test]
 script:
   - pytest tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ python:
   - "2.7"
   - "3.5"
   - "3.6.1"
+install:
+  - pip install kount_ris_sdk
 script:
   - pytest tests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Welcome to the kount-ris-python-sdk wiki!
 
+![Travis CI status](https://travis-ci.org/Kount/kount-ris-python-sdk.svg?branch=master)
+
 # Kount Python RIS SDK #
 
 Contains the Kount Python SDK, tests, and build/package routines.


### PR DESCRIPTION
Adding Travis CI to the Project to ensure unit tests pass.