### PR TITLE
Updated SDK VERSION 0695 to 0700 for Python SDK

### DIFF
--- a/src/kount/config.py
+++ b/src/kount/config.py
@@ -20,7 +20,7 @@ class SDKConfig:
     # field validation rules
     _XML_FILENAME = os.path.join(resources.__path__[0], 'validate.xml')
 
-    SDK_VERSION = "0695"
+    SDK_VERSION = "0700"
 
     # default behaviour for request failures
     _RAISE_ERRORS = True

--- a/tests/json_test.py
+++ b/tests/json_test.py
@@ -58,7 +58,7 @@ example_data = {
             'AppleWebKit%2F537.36+%28KHTML%2C+like+Gecko%29+'\
             'Chrome%2F37.0.2062.124+Safari%2F537.36',
     'UNIQ': '088E9F4961354D4F9004',
-    'VERS': '0695'
+    'VERS': '0700'
 }
 
 example_data_products = {
@@ -111,5 +111,5 @@ example_data_products = {
             'Chrome%2F37.0.2062.124+Safari%2F537.36',
     'UNIQ': 'F8E874A38B7B4B6DBB71',
     'SDK': 'CUST',
-    'VERS': '0695'
+    'VERS': '0700'
     }

--- a/tests/test_api_kount.py
+++ b/tests/test_api_kount.py
@@ -78,7 +78,7 @@ expected1 = {
     'SITE': 'DEFAULT',
     'TIMEZONE': None,
     'UAS': None,
-    'VERS': '0695',
+    'VERS': '0700',
     'VOICE_DEVICE': None,
     'WARNING_COUNT': 0}
 
@@ -138,7 +138,7 @@ CURLED = {
     'SITE': 'DEFAULT',
     'TOTL': '123456',
     'UNIQ': '088E9F4961354D4F9004',
-    'VERS': '0695'}
+    'VERS': '0700'}
 
 
 @pytest.mark.usefixtures("api_url", "api_key", "merchant_id")
@@ -163,7 +163,7 @@ class TestAPIRIS(unittest.TestCase):
         data = CURLED
         self.assertIn('MODE', CURLED)
         expected = {
-            "VERS": "0695", "MODE": "Q", "TRAN": "PTPN0Z04P8Y6",
+            "VERS": "0700", "MODE": "Q", "TRAN": "PTPN0Z04P8Y6",
             "MERC": "999666", "SESS": "088E9F4961354D4F90041988B8D5C66B",
             "ORDR": "088E9F496135", "AUTO": "R", "SCOR": "29", "GEOX": "US",
             "BRND": None, "REGN": None, "NETW": "N", "KAPT": "N", "CARDS": "1",

--- a/tests/test_bed_examples.py
+++ b/tests/test_bed_examples.py
@@ -52,7 +52,7 @@ def user_inquiry(session_id, merchant_id, email_client, payment):
     cart_items = [CartItem("1", "8482", "Standard Monthly Plan", 1, '3500')]
     result.set_shopping_cart(cart_items)
     result.version()
-    result.set_version(SDKConfig.SDK_VERSION)  # 0695
+    result.set_version(SDKConfig.SDK_VERSION)  # 0700
     result.set_merchant(merchant_id)
     result.set_payment(payment)  # PTOK
     result.set_session_id(session_id)  # SESS
@@ -104,7 +104,7 @@ expected = {
     'SITE': 'DEFAULT',
     'TOTL': 3500,
     # 'UNIQ': '4F7132C2FE8547928CD9',
-    'VERS': '0695'}
+    'VERS': '0700'}
 
 
 @pytest.mark.usefixtures("api_url", "api_key", "merchant_id")


### PR DESCRIPTION
Updated default SDK version '0695' to '0700' for Python SDK (all code).