### PR TITLE
Git lab cd

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,20 +7,6 @@ before_script:
    - pip install twine
    - python setup.py sdist bdist_wheel
 
-# Upload to Test PyPi
-# Test PyPi may delete our user account without warning.
-# This is brittle, and we may want to remove the stage
-# deployment and replace it with true CI validation.
-deploy_staging:
-  stage: deploy
-  variables:
-    TWINE_USERNAME: $STAGING_USERNAME
-    TWINE_PASSWORD: $STAGING_PASSWORD
-  script:
-    - twine upload --repository-url $STAGING_REPO_URL dist/*
-  except:
-    - tags
-
 deploy_production:
   stage: deploy
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,19 +5,18 @@ stages:
 
 before_script:
    - pip install twine
-   # "You should always upload a source archive and provide built archives..." - PyPi
-   #- python setup.py sdist bdist_wheel
-   # Do we want to do what old internal documentation referenced?
-   - python setup.py bdist_wheel --universal
+   - python setup.py sdist bdist_wheel
 
 # Upload to Test PyPi
+# Test PyPi may delete our user account without warning.
+# This is brittle, and we may want to remove the stage
+# deployment and replace it with true CI validation.
 deploy_staging:
   stage: deploy
   variables:
     TWINE_USERNAME: $STAGING_USERNAME
     TWINE_PASSWORD: $STAGING_PASSWORD
   script:
-    #- twine upload dist/*
     - twine upload --repository-url $STAGING_REPO_URL dist/*
   except:
     - tags

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,9 +6,9 @@ stages:
 before_script:
    - pip install twine
    # "You should always upload a source archive and provide built archives..." - PyPi
-   - python setup.py sdist bdist_wheel
+   #- python setup.py sdist bdist_wheel
    # Do we want to do what old internal documentation referenced?
-   #- python setup.py bdist_wheel --universal
+   - python setup.py bdist_wheel --universal
 
 # Upload to Test PyPi
 deploy_staging:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,18 +5,20 @@ stages:
 
 before_script:
    - pip install twine
-   - python setup.py sdist
-   # Do we want to do what old internal documentation referenced instead of sdist?
+   # "You should always upload a source archive and provide built archives..." - PyPi
+   - python setup.py sdist bdist_wheel
+   # Do we want to do what old internal documentation referenced?
    #- python setup.py bdist_wheel --universal
 
+# Upload to Test PyPi
 deploy_staging:
   stage: deploy
   variables:
     TWINE_USERNAME: $STAGING_USERNAME
     TWINE_PASSWORD: $STAGING_PASSWORD
   script:
-    - twine upload dist/*
-    #- twine upload --repository-url $PYPRI_REPOSITORY_URL dist/*
+    #- twine upload dist/*
+    - twine upload --repository-url $STAGING_REPO_URL dist/*
   except:
     - tags
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,31 @@
+image: python:3.6-alpine
+  
+stages:
+  - deploy
+
+before_script:
+   - pip install twine
+   - python setup.py sdist
+   # Do we want to do what old internal documentation referenced instead of sdist?
+   #- python setup.py bdist_wheel --universal
+
+deploy_staging:
+  stage: deploy
+  variables:
+    TWINE_USERNAME: $STAGING_USERNAME
+    TWINE_PASSWORD: $STAGING_PASSWORD
+  script:
+    - twine upload dist/*
+    #- twine upload --repository-url $PYPRI_REPOSITORY_URL dist/*
+  except:
+    - tags
+
+deploy_production:
+  stage: deploy
+  variables:
+    TWINE_USERNAME: $PRODUCTION_USERNAME
+    TWINE_PASSWORD: $PRODUCTION_PASSWORD
+  script:
+    - twine upload dist/*
+  only:
+    - tags

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ with open(os.path.join(this_path, 'README.md'), encoding='utf-8') as f:
 
 REQUIRES = (
     'requests>=2.11.1',
-    'mom==0.1.3;python_version<"3.0"',
+    'mom>=0.1.3;python_version<"3.0"',
     'py2-ipaddress>=3.4.1;python_version<"3.0"'
 )
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ KEYWORDS = ('kount', 'sdk', 'ris')
 
 # Think this can go away if GitLab sets the version based on CI_COMMIT_TAG (gallilama)
 #main_ns = {}
-#this_path = os.path.abspath(os.path.dirname(__file__))
+this_path = os.path.abspath(os.path.dirname(__file__))
 #version_file = os.path.join(this_path, 'src/{0}/version.py'.format(
 #    PROJECT_MODULE))
 #with open(version_file) as ver_file:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ with open(os.path.join(this_path, 'README.md'), encoding='utf-8') as f:
 
 REQUIRES = (
     'requests>=2.11.1',
-    'mom>=0.1.3;python_version<"3.0"',
+    'mom==0.1.3;python_version<"3.0"',
     'py2-ipaddress>=3.4.1;python_version<"3.0"'
 )
 

--- a/setup.py
+++ b/setup.py
@@ -30,17 +30,9 @@ KEYWORDS = ('kount', 'sdk', 'ris')
 
 # Version can be set dynamically by GitLab, but other things in the
 # SDK appear to be using the value in version.py.
-# I'm not sure if we should adopt dynamic version in GitLab or not.
-# It's shiny, but if other things want the verion info in the file,
-# then things could get confusing.  Going to leave the dynamic GitLab
-# stuff in here along with this long comment. (gallilama)
-#main_ns = {}
+# Developers SHOULD STILL UPDATE the value in version.py for other needs.
+
 this_path = os.path.abspath(os.path.dirname(__file__))
-#version_file = os.path.join(this_path, 'src/{0}/version.py'.format(
-#    PROJECT_MODULE))
-#with open(version_file) as ver_file:
-#    exec(ver_file.read(), main_ns)
-#    VERSION = main_ns['VERSION']
 
 # Get the long description from the README file
 with open(os.path.join(this_path, 'README.md'), encoding='utf-8') as f:

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ if __name__ == '__main__':
         version=VERSION,
         description=DESC,
         long_description=LONG_DESC,
+        long_description_content_type="text/markdown",
         url=PROJECT_URL,
         author=AUTHOR,
         author_email=EMAIL,

--- a/setup.py
+++ b/setup.py
@@ -11,24 +11,31 @@ import os
 from codecs import open
 from setuptools import setup, find_packages
 
+# GitLab env value will now dynamically set the version (gallilama)
+if os.environ.get('CI_COMMIT_TAG'):
+    version = os.environ['CI_COMMIT_TAG']
+else:
+    version = os.environ['CI_JOB_ID']
+
 AUTHOR = 'Kount'
 EMAIL = 'sdkadmin@kount.com'
 PROJECT = 'kount_ris_sdk'
 PROJECT_MODULE = 'kount'
-VERSION = '<unknown>'
+VERSION = version
 PROJECT_URL = 'https://github.com/Kount/kount-ris-python-sdk'
 DESC = 'Kount Python RIS SDK'
 LONG_DESC = ''
 LICENSE = 'Kount'
 KEYWORDS = ('kount', 'sdk', 'ris')
 
-main_ns = {}
-this_path = os.path.abspath(os.path.dirname(__file__))
-version_file = os.path.join(this_path, 'src/{0}/version.py'.format(
-    PROJECT_MODULE))
-with open(version_file) as ver_file:
-    exec(ver_file.read(), main_ns)
-    VERSION = main_ns['VERSION']
+# Think this can go away if GitLab sets the version based on CI_COMMIT_TAG (gallilama)
+#main_ns = {}
+#this_path = os.path.abspath(os.path.dirname(__file__))
+#version_file = os.path.join(this_path, 'src/{0}/version.py'.format(
+#    PROJECT_MODULE))
+#with open(version_file) as ver_file:
+#    exec(ver_file.read(), main_ns)
+#    VERSION = main_ns['VERSION']
 
 # Get the long description from the README file
 with open(os.path.join(this_path, 'README.md'), encoding='utf-8') as f:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,12 @@ LONG_DESC = ''
 LICENSE = 'Kount'
 KEYWORDS = ('kount', 'sdk', 'ris')
 
-# Think this can go away if GitLab sets the version based on CI_COMMIT_TAG (gallilama)
+# Version can be set dynamically by GitLab, but other things in the
+# SDK appear to be using the value in version.py.
+# I'm not sure if we should adopt dynamic version in GitLab or not.
+# It's shiny, but if other things want the verion info in the file,
+# then things could get confusing.  Going to leave the dynamic GitLab
+# stuff in here along with this long comment. (gallilama)
 #main_ns = {}
 this_path = os.path.abspath(os.path.dirname(__file__))
 #version_file = os.path.join(this_path, 'src/{0}/version.py'.format(


### PR DESCRIPTION
This PR introduces a GitLab based deployment pipeline for the Python RIS SDK.

The pipeline will be triggered on-Tag.  GitLab's Pull Mirror of this GitHub repo will detect the Tag, and then initiate the deployment pipeline defined in .gitlab-ci.yml.  In my testing GitLab detects the Tag within ~30 minutes.

This removes the need to distribute PyPi credentials to developers, and automates / standardizes our package deployment process.