### PR TITLE
Fix Undefined MERCHANT_ID Crash

### DIFF
--- a/src/kount/settings.py
+++ b/src/kount/settings.py
@@ -8,4 +8,4 @@ MAINTAINER_EMAIL = "sdkadmin@kount.com"
 DEFAULT_TIMEOUT = None
 TEST_API_URL = "API_URL" # provided by kount
 TEST_API_KEY = "API_KEY" # kount API Key
-TEST_MERCHANT_ID =  MERCHANT_ID # provided by kount
+TEST_MERCHANT_ID =  "MERCHANT_ID" # provided by kount


### PR DESCRIPTION
Currently, when importing any modules from the Kount API, we get a crash for a missing MERCHANT_ID define.
Reported here https://github.com/Kount/kount-ris-python-sdk/issues/28

This fixes the crash by simply converting the define to a string as with the other settings in this file.